### PR TITLE
removing duplicate call to populateOptions() that was causing a bug

### DIFF
--- a/src/Groff/Command/ArgumentParser.php
+++ b/src/Groff/Command/ArgumentParser.php
@@ -71,7 +71,7 @@ class ArgumentParser
 
     public function getArgument($index = 0)
     {
-        return $this->arguments[$index];
+        return isset($this->arguments[$index]) ? $this->arguments[$index] : null;
     }
 
     public function getArguments()

--- a/src/Groff/Command/Command.php
+++ b/src/Groff/Command/Command.php
@@ -107,8 +107,6 @@ abstract class Command
 
         $this->addHelpCommand();
 
-        $this->populateOptions();
-
         $this->notify("options available");
 
         if ($this->option("help")) {


### PR DESCRIPTION
this was the cause of the issue i was having running a command with no project arguments and not getting a project listing